### PR TITLE
都道府県の選択UIを作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@next/env": "^14.2.1",
     "next": "14.1.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "recoil": "^0.7.7"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/src/app/_TopPage/PrefectureChoice.tsx
+++ b/src/app/_TopPage/PrefectureChoice.tsx
@@ -1,4 +1,4 @@
-import CheckBox from '@/components/atom/CheckBox'
+import RegionCheckBox from '@/app/_TopPage/RegionCheckBox'
 import { groupByRegion } from '@/lib/prefecture'
 import { fetchResasPrefectures } from '@/server/lib/api'
 
@@ -12,14 +12,20 @@ export default async function PrefectureChoice({ className }: Props) {
 
   return (
     <div className={className}>
-      <div className='mb-4'>
-        <h2 className='mb-2 text-xl'>北海道・東北</h2>
-        <div className='flex gap-6'>
-          {prefGroupByRegion.hokkaidoTohoku.map((v) => (
-            <CheckBox key={v.prefCode} label={v.prefName} />
-          ))}
-        </div>
-      </div>
+      <RegionCheckBox
+        title='北海道・東北'
+        prefectures={prefGroupByRegion.hokkaidoTohoku}
+        className='mb-6'
+      />
+      <RegionCheckBox title='関東' prefectures={prefGroupByRegion.kanto} className='mb-6' />
+      <RegionCheckBox title='中部' prefectures={prefGroupByRegion.tyubu} className='mb-6' />
+      <RegionCheckBox title='近畿' prefectures={prefGroupByRegion.kinki} className='mb-6' />
+      <RegionCheckBox
+        title='中国・四国'
+        prefectures={prefGroupByRegion.tyugokuSikoku}
+        className='mb-6'
+      />
+      <RegionCheckBox title='九州・沖縄' prefectures={prefGroupByRegion.kyusyuOkinawa} />
     </div>
   )
 }

--- a/src/app/_TopPage/PrefectureChoice.tsx
+++ b/src/app/_TopPage/PrefectureChoice.tsx
@@ -1,0 +1,27 @@
+import CheckBox from '@/components/atom/CheckBox'
+import { HOKKAIDO_TOHOKU_PREF_IDS } from '@/constant'
+import { fetchResasPrefectures } from '@/server/lib/api'
+
+type Props = {
+  className?: string
+}
+
+export default async function PrefectureChoice({ className }: Props) {
+  const prefectures = await fetchResasPrefectures()
+  const hokkaidoTohokuPrefs = prefectures.result.filter((v) =>
+    HOKKAIDO_TOHOKU_PREF_IDS.includes(v.prefCode),
+  )
+
+  return (
+    <div className={className}>
+      <div className='mb-4'>
+        <h2 className='mb-2 text-xl'>北海道・東北</h2>
+        <div className='flex gap-6'>
+          {hokkaidoTohokuPrefs.map((v) => (
+            <CheckBox key={v.prefCode} label={v.prefName} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/_TopPage/PrefectureChoice.tsx
+++ b/src/app/_TopPage/PrefectureChoice.tsx
@@ -1,5 +1,5 @@
 import CheckBox from '@/components/atom/CheckBox'
-import { HOKKAIDO_TOHOKU_PREF_IDS } from '@/constant'
+import { groupByRegion } from '@/lib/prefecture'
 import { fetchResasPrefectures } from '@/server/lib/api'
 
 type Props = {
@@ -8,16 +8,14 @@ type Props = {
 
 export default async function PrefectureChoice({ className }: Props) {
   const prefectures = await fetchResasPrefectures()
-  const hokkaidoTohokuPrefs = prefectures.result.filter((v) =>
-    HOKKAIDO_TOHOKU_PREF_IDS.includes(v.prefCode),
-  )
+  const prefGroupByRegion = groupByRegion(prefectures.result)
 
   return (
     <div className={className}>
       <div className='mb-4'>
         <h2 className='mb-2 text-xl'>北海道・東北</h2>
         <div className='flex gap-6'>
-          {hokkaidoTohokuPrefs.map((v) => (
+          {prefGroupByRegion.hokkaidoTohoku.map((v) => (
             <CheckBox key={v.prefCode} label={v.prefName} />
           ))}
         </div>

--- a/src/app/_TopPage/RegionCheckBox.tsx
+++ b/src/app/_TopPage/RegionCheckBox.tsx
@@ -1,0 +1,23 @@
+import CheckBox from '@/components/atom/CheckBox'
+import { ResasPrefecture } from '@/types/api'
+
+type Props = {
+  title: string
+  prefectures: ResasPrefecture[]
+  className?: string
+}
+
+export default function RegionCheckBox({ title, prefectures, className }: Props) {
+  return (
+    <div className={className}>
+      <h2 className='mb-4 text-2xl before:mr-2 before:rounded-full before:border-l-8 before:border-lime-400'>
+        {title}
+      </h2>
+      <div className='flex flex-wrap gap-x-6 gap-y-4'>
+        {prefectures.map((v) => (
+          <CheckBox key={v.prefCode} label={v.prefName} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/_TopPage/RegionCheckBox.tsx
+++ b/src/app/_TopPage/RegionCheckBox.tsx
@@ -1,5 +1,11 @@
+'use client'
+
+import { useCallback } from 'react'
+
 import CheckBox from '@/components/atom/CheckBox'
+import { selectedPrefListState } from '@/store'
 import { ResasPrefecture } from '@/types/api'
+import { useRecoilState } from 'recoil'
 
 type Props = {
   title: string
@@ -8,6 +14,21 @@ type Props = {
 }
 
 export default function RegionCheckBox({ title, prefectures, className }: Props) {
+  const [_, setSelectedPrefList] = useRecoilState(selectedPrefListState)
+
+  const handleChange = useCallback(
+    (isChecked: boolean, prefCode: number) => {
+      if (isChecked) {
+        // ONにする
+        setSelectedPrefList((prev) => [...prev, prefCode])
+      } else {
+        // OFFにする
+        setSelectedPrefList((prev) => prev.filter((v) => v !== prefCode))
+      }
+    },
+    [setSelectedPrefList],
+  )
+
   return (
     <div className={className}>
       <h2 className='mb-4 text-2xl before:mr-2 before:rounded-full before:border-l-8 before:border-lime-400'>
@@ -15,7 +36,11 @@ export default function RegionCheckBox({ title, prefectures, className }: Props)
       </h2>
       <div className='flex flex-wrap gap-x-6 gap-y-4'>
         {prefectures.map((v) => (
-          <CheckBox key={v.prefCode} label={v.prefName} />
+          <CheckBox
+            key={v.prefCode}
+            label={v.prefName}
+            onChange={(e) => handleChange(e.target.checked, v.prefCode)}
+          />
         ))}
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import '@/app/globals.css'
+import RecoilProvider from '@/components/context/RecoilProvider'
 import Footer from '@/components/usecase/Footer'
 import Header from '@/components/usecase/Header'
 
@@ -17,9 +18,11 @@ export default function RootLayout({
   return (
     <html lang='ja' className='h-full'>
       <body className='h-full bg-gray-100'>
-        <Header />
-        {children}
-        <Footer />
+        <RecoilProvider>
+          <Header />
+          {children}
+          <Footer />
+        </RecoilProvider>
       </body>
     </html>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ja' className='h-full'>
-      <body className='h-full'>
+      <body className='h-full bg-gray-100'>
         <Header />
         {children}
         <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,25 @@
+import CheckBox from '@/components/atom/CheckBox'
+import { HOKKAIDO_TOHOKU_PREF_IDS } from '@/constant'
+import { fetchResasPrefectures } from '@/server/lib/api'
+
 export default async function TopPage() {
+  const prefectures = await fetchResasPrefectures()
+  const hokkaidoTohokuPrefs = prefectures.result.filter((v) =>
+    HOKKAIDO_TOHOKU_PREF_IDS.includes(v.prefCode),
+  )
+
   return (
-    <main>
-      <p></p>
+    <main className='mx-auto mt-16 max-w-screen-lg rounded-md bg-white'>
+      <div className='p-16'>
+        <div className='mb-4'>
+          <h2 className='mb-2 text-xl'>北海道・東北</h2>
+          <div className='flex gap-6'>
+            {hokkaidoTohokuPrefs.map((v) => (
+              <CheckBox key={v.prefCode} label={v.prefName} />
+            ))}
+          </div>
+        </div>
+      </div>
     </main>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,9 @@
-import CheckBox from '@/components/atom/CheckBox'
-import { HOKKAIDO_TOHOKU_PREF_IDS } from '@/constant'
-import { fetchResasPrefectures } from '@/server/lib/api'
+import PrefectureChoice from '@/app/_TopPage/PrefectureChoice'
 
 export default async function TopPage() {
-  const prefectures = await fetchResasPrefectures()
-  const hokkaidoTohokuPrefs = prefectures.result.filter((v) =>
-    HOKKAIDO_TOHOKU_PREF_IDS.includes(v.prefCode),
-  )
-
   return (
-    <main className='mx-auto mt-16 max-w-screen-lg rounded-md bg-white'>
-      <div className='p-16'>
-        <div className='mb-4'>
-          <h2 className='mb-2 text-xl'>北海道・東北</h2>
-          <div className='flex gap-6'>
-            {hokkaidoTohokuPrefs.map((v) => (
-              <CheckBox key={v.prefCode} label={v.prefName} />
-            ))}
-          </div>
-        </div>
-      </div>
+    <main className='mx-auto mt-16 max-w-screen-lg rounded-md bg-white p-16'>
+      <PrefectureChoice />
     </main>
   )
 }

--- a/src/components/atom/CheckBox.tsx
+++ b/src/components/atom/CheckBox.tsx
@@ -1,0 +1,33 @@
+import { ComponentPropsWithoutRef } from 'react'
+
+type Props = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
+  label?: string
+}
+
+export default function CheckBox({ label, ...props }: Props) {
+  return (
+    <label className='flex cursor-pointer items-center gap-2'>
+      <div>
+        <input type='checkbox' className='peer hidden' {...props} />
+        <div
+          className='relative size-6 rounded border-2
+                    peer-checked:border-none
+                  peer-checked:bg-lime-400
+                    peer-checked:before:absolute
+                    peer-checked:before:left-2.5
+                    peer-checked:before:top-[5px]
+                    peer-checked:before:block
+                    peer-checked:before:h-3
+                    peer-checked:before:w-1.5
+                    peer-checked:before:rotate-45
+                    peer-checked:before:border-b-[3px]
+                    peer-checked:before:border-r-[3px]
+                    peer-checked:before:border-white
+                    peer-checked:before:content-[""]'
+        />
+      </div>
+
+      <span>{label}</span>
+    </label>
+  )
+}

--- a/src/components/atom/CheckBox.tsx
+++ b/src/components/atom/CheckBox.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { ComponentPropsWithoutRef } from 'react'
 
 type Props = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {

--- a/src/components/atom/CheckBox.tsx
+++ b/src/components/atom/CheckBox.tsx
@@ -12,7 +12,7 @@ export default function CheckBox({ label, ...props }: Props) {
       <div>
         <input type='checkbox' className='peer hidden' {...props} />
         <div
-          className='relative size-6 rounded border-2
+          className='relative size-6 rounded border-2 border-gray-400
                     peer-checked:border-none
                   peer-checked:bg-lime-400
                     peer-checked:before:absolute

--- a/src/components/context/RecoilProvider.tsx
+++ b/src/components/context/RecoilProvider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+import { RecoilRoot } from 'recoil'
+
+function RecoilProvider({ children }: { children: ReactNode }) {
+  return <RecoilRoot>{children}</RecoilRoot>
+}
+
+export default RecoilProvider

--- a/src/constant/index.tsx
+++ b/src/constant/index.tsx
@@ -1,1 +1,0 @@
-export const HOKKAIDO_TOHOKU_PREF_IDS = [1, 2, 3, 4, 5, 6, 7]

--- a/src/constant/index.tsx
+++ b/src/constant/index.tsx
@@ -1,0 +1,1 @@
+export const HOKKAIDO_TOHOKU_PREF_IDS = [1, 2, 3, 4, 5, 6, 7]

--- a/src/lib/prefecture.ts
+++ b/src/lib/prefecture.ts
@@ -1,0 +1,20 @@
+import { PrefectureGroupByRegion } from '@/types'
+import { ResasPrefecture } from '@/types/api'
+
+export const HOKKAIDO_TOHOKU_PREF_IDS = [1, 2, 3, 4, 5, 6, 7]
+export const KANTO_PREF_IDS = [8, 9, 10, 11, 12, 13, 14]
+export const TYUBU_PREF_IDS = [15, 16, 17, 18, 19, 20, 21, 22, 23]
+export const KINKI_PREF_IDS = [24, 25, 26, 27, 28, 29, 30]
+export const TYUGOKU_SIKOKU_PREF_IDS = [31, 32, 33, 34, 35, 36, 37, 38, 39]
+export const KYUSYU_OKINAWA_PREF_IDS = [40, 41, 42, 43, 44, 45, 46, 47]
+
+export const groupByRegion = (prefectures: ResasPrefecture[]): PrefectureGroupByRegion => {
+  return {
+    hokkaidoTohoku: prefectures.filter((v) => HOKKAIDO_TOHOKU_PREF_IDS.includes(v.prefCode)),
+    kanto: prefectures.filter((v) => KANTO_PREF_IDS.includes(v.prefCode)),
+    tyubu: prefectures.filter((v) => TYUBU_PREF_IDS.includes(v.prefCode)),
+    kinki: prefectures.filter((v) => KINKI_PREF_IDS.includes(v.prefCode)),
+    tyugokuSikoku: prefectures.filter((v) => TYUGOKU_SIKOKU_PREF_IDS.includes(v.prefCode)),
+    kyusyuOkinawa: prefectures.filter((v) => KYUSYU_OKINAWA_PREF_IDS.includes(v.prefCode)),
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil'
+
+export const selectedPrefListState = atom<number[]>({
+  key: 'selectedPrefList',
+  default: [],
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,10 @@
+import { ResasPrefecture } from '@/types/api'
+
+export type PrefectureGroupByRegion = {
+  hokkaidoTohoku: ResasPrefecture[]
+  kanto: ResasPrefecture[]
+  tyubu: ResasPrefecture[]
+  kinki: ResasPrefecture[]
+  tyugokuSikoku: ResasPrefecture[]
+  kyusyuOkinawa: ResasPrefecture[]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,6 +3276,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hamt_plus@npm:1.0.2":
+  version: 1.0.2
+  resolution: "hamt_plus@npm:1.0.2"
+  checksum: 10c0/c5aa5cc08228e8cc2a90150fef680bd5b09f16a327bdab799daeb80fd3c987663308b14e2c6718abdf75afce21d29607e35f2705eb336a14aa935c0ca5949ce7
+  languageName: node
+  linkType: hard
+
 "has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-bigints@npm:1.0.2"
@@ -5433,6 +5440,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"recoil@npm:^0.7.7":
+  version: 0.7.7
+  resolution: "recoil@npm:0.7.7"
+  dependencies:
+    hamt_plus: "npm:1.0.2"
+  peerDependencies:
+    react: ">=16.13.1"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 10c0/630a73b0bdfb1b453c68eca9b3fa0771d489006fbd856a7700174d775978ba3faa10d251ac2af7c07142014dcba07c2b103f448ecc19b6124d3228ec810f5c28
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.4":
   version: 1.0.6
   resolution: "reflect.getprototypeof@npm:1.0.6"
@@ -6601,6 +6624,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     react: "npm:^18"
     react-dom: "npm:^18"
+    recoil: "npm:^0.7.7"
     tailwindcss: "npm:^3.3.0"
     ts-jest: "npm:^29.1.2"
     typescript: "npm:^5"


### PR DESCRIPTION
## 概要
close #5 

タイトルの通り

## 画面
<img width="733" alt="image" src="https://github.com/karintou8710/yumemi-passport-frontend/assets/80200187/9ecbb5e1-6eae-4083-a8b4-1745343d5d39">

## その他
- 状態管理用にRecoilを追加。都道府県の選択状態をバケツリレーで渡すことを回避。